### PR TITLE
fix: multiprocess export failed processes

### DIFF
--- a/Console/Command/Process.php
+++ b/Console/Command/Process.php
@@ -109,8 +109,10 @@ class Process extends Command
 
             $fh = fopen($filePath, 'ab');
             if (!$fh) {
-                $this->_helper->logProfiler('Cannot create file from separate process.', '');
-                return;
+                throw new \Exception(sprintf(
+                    "Can't create file %s",
+                    $filePath
+                ));
             }
 
             $ids = $this->_json->unserialize(
@@ -131,7 +133,13 @@ class Process extends Command
 
             $output->writeln(0);
         } catch (\Exception $e) {
-            $this->_helper->logProfiler('Caught exception: ' . $e->getMessage(), $chunkId);
+            $this->_helper->logProfiler('Caught exception: ' . $e->getMessage(), $processId);
+            $this->_cache->save(
+                $e->getMessage(),
+                'process_' . $processId . '_' . $chunkId,
+                [],
+                Exporter::CACHE_LIFETIME
+            );
             $output->writeln(1);
         }
     }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -213,7 +213,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
         return (bool)$this->scopeConfig->getValue(
             self::CONFIG_ENABLED,
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
+            ScopeInterface::SCOPE_STORES,
             $store
         );
     }
@@ -226,7 +226,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
         return (bool)$this->scopeConfig->getValue(
             self::CONFIG_EXPORT_ORDERS,
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
+            ScopeInterface::SCOPE_STORES,
             $store
         );
     }
@@ -239,7 +239,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
         return $this->scopeConfig->getValue(
             self::CONFIG_EXPORT_ORDERS_FILENAME,
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
+            ScopeInterface::SCOPE_STORES,
             $store
         );
     }
@@ -257,7 +257,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     {
         return $this->scopeConfig->getValue(
             self::CONFIG_EXPORT_CONF_ENV_STAMP,
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORES
+            ScopeInterface::SCOPE_STORES
         );
     }
 
@@ -288,15 +288,31 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
     public function getNotificationsEmail($store = null)
     {
-        if ($store === null) {
-            $store = $this->getCurrentStore();
-        }
-
         return $this->scopeConfig->getValue(
             self::CONFIG_NOTIFICATION_EMAIL,
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
+            ScopeInterface::SCOPE_STORES,
             $store
         );
+    }
+
+    /**
+     * @param $store
+     * @return array
+     */
+    public function getNotificationFrom($store = null)
+    {
+        return [
+            'name' => $this->scopeConfig->getValue(
+                'trans_email/ident_general/name',
+                ScopeInterface::SCOPE_STORES,
+                $store
+            ),
+            'email' => $this->scopeConfig->getValue(
+                'trans_email/ident_general/email',
+                ScopeInterface::SCOPE_STORES,
+                $store
+            )
+        ];
     }
 
     public function useIndexedPrices()
@@ -414,7 +430,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             ",",
             (string)$this->scopeConfig->getValue(
                 self::CONFIG_EXPORT_AUTOSCHEDULE_EVENTS,
-                \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
+                ScopeInterface::SCOPE_STORES,
                 $store
             )
         );

--- a/Helper/Export.php
+++ b/Helper/Export.php
@@ -395,7 +395,7 @@ class Export extends Data
     {
         $this->_storeId = $storeId;
         $websiteId = $this->storeManager->getStore($storeId)->getWebsiteId();
-        $str = null;
+        $str = '';
         $this->setCurrentStore($this->_storeId);
         $entityName = $this->getProductEntityIdName("catalog_product_entity");
         $productCollection = $this->productCollectionFactory->create();

--- a/Observer/CatalogUpdate.php
+++ b/Observer/CatalogUpdate.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Celebros (C) 2023. All Rights Reserved.
+ * Celebros (C) 2024. All Rights Reserved.
  *
  * DISCLAIMER
  *
@@ -9,30 +9,29 @@
  */
 namespace Celebros\Celexport\Observer;
 
-use Magento\Framework\Event\ObserverInterface;
+use Celebros\Celexport\Model\ExportManagement;
 
 class CatalogUpdate
 {
     /**
-     * @var \Celebros\Celexport\Model\Exporter
+     * @var ExportManagement
      */
-    private $exporter;
+    private ExportManagement $exportManagement;
 
     /**
-     * @param \Celebros\Celexport\Model\Exporter $exporter
+     * @param ExportManagement $exportManagement
      */
     public function __construct(
-        \Celebros\Celexport\Model\Exporter $exporter
+        ExportManagement $exportManagement
     ) {
-        $this->exporter = $exporter;
+        $this->exportManagement = $exportManagement;
     }
 
     /**
-     * @inheritDoc
+     * Run export by cron
      */
-    public function execute($observer)
+    public function execute()
     {
-        $this->exporter->export_celebros(false);
-        return $this;
+        $this->exportManagement->startExportProcess();
     }
 }


### PR DESCRIPTION
When one of the processes fails during multi-process export then export processes terminates and displays corresponding messages, a notification email is sent and partial export bundle is not sent to SFTP

feat: merge products from two separate files into a single one

Now products from source_products.txt and categoryless_products.txt files are merged into one source_products.txt.